### PR TITLE
feat: ClassDay 엔티티 분리 [#6]

### DIFF
--- a/src/main/java/com/tutorpus/tutorpus/connect/controller/ConnectController.java
+++ b/src/main/java/com/tutorpus/tutorpus/connect/controller/ConnectController.java
@@ -5,6 +5,8 @@ import com.tutorpus.tutorpus.auth.dto.SessionMember;
 import com.tutorpus.tutorpus.connect.dto.ConnectRequestDto;
 import com.tutorpus.tutorpus.connect.service.ConnectService;
 import com.tutorpus.tutorpus.member.entity.Member;
+import com.tutorpus.tutorpus.member.entity.Role;
+import com.tutorpus.tutorpus.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,9 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ConnectController {
     private final ConnectService connectService;
+    private final MemberRepository memberRepository;
 
     @PostMapping()
     public ResponseEntity<?> teacherStudentConnect(@RequestBody ConnectRequestDto connectDto, @LoginUser Member member){
+        //선생님만 학생 추가 가능
+        if (member.getRole() == Role.STUDENT) return ResponseEntity.ok("선생님만 학생 추가 가능");
         connectService.teacherStudentConnect(connectDto, member);
         return ResponseEntity.ok("선생님과 학생 연결 완료");
     }

--- a/src/main/java/com/tutorpus/tutorpus/connect/entity/ClassDay.java
+++ b/src/main/java/com/tutorpus/tutorpus/connect/entity/ClassDay.java
@@ -1,0 +1,54 @@
+package com.tutorpus.tutorpus.connect.entity;
+
+import com.tutorpus.tutorpus.connect.entity.Connect;
+import com.tutorpus.tutorpus.connect.entity.Day;
+import com.tutorpus.tutorpus.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class ClassDay {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //선생님과 학생 연결 id
+    @ManyToOne
+    @JoinColumn(name = "connect_id", referencedColumnName = "id", nullable = false)
+    private Connect connect;
+
+    //요일
+    @Column(name = "day_of_week", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Day day;
+
+    //과외 시작 시간
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    //과외 종료 시간
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    //과외 시작 일자(오늘 날짜를 기준)
+    @Column(name = "start_date", nullable = false)
+    @CreationTimestamp
+    private LocalDate startDate;
+
+    @Builder
+    public ClassDay(Connect connect, Day day, LocalTime startTime, LocalTime endTime){
+        this.connect = connect;
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+}
+

--- a/src/main/java/com/tutorpus/tutorpus/connect/entity/Connect.java
+++ b/src/main/java/com/tutorpus/tutorpus/connect/entity/Connect.java
@@ -19,42 +19,21 @@ public class Connect {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "teacher_id", referencedColumnName = "id")
+    @JoinColumn(name = "teacher_id", referencedColumnName = "id", nullable = false)
     private Member teacher;
 
     @ManyToOne
-    @JoinColumn(name = "student_id", referencedColumnName = "id")
+    @JoinColumn(name = "student_id", referencedColumnName = "id", nullable = false)
     private Member student;
 
     //과목명
     @Column(nullable = false)
     private String subject;
 
-    //요일
-    @Column(name = "day_of_week", nullable = false)
-    @Enumerated(EnumType.STRING)
-    private Day day;
-
-    //과외 시작 시간
-    @Column(name = "start_time", nullable = false)
-    private LocalTime startTime;
-
-    //과외 종료 시간
-    @Column(name = "end_time", nullable = false)
-    private LocalTime endTime;
-
-    //과외 시작 일자(오늘 날짜를 기준)
-    @Column(name = "start_date", nullable = false)
-    @CreationTimestamp
-    private LocalDate startDate;
-
     @Builder
-    public Connect(Member teacher, Member student, String subject, Day day, LocalTime startTime, LocalTime endTime){
+    public Connect(Member teacher, Member student, String subject){
         this.teacher = teacher;
         this.student = student;
         this.subject = subject;
-        this.day = day;
-        this.startTime = startTime;
-        this.endTime = endTime;
     }
 }

--- a/src/main/java/com/tutorpus/tutorpus/connect/repository/ClassDayRepository.java
+++ b/src/main/java/com/tutorpus/tutorpus/connect/repository/ClassDayRepository.java
@@ -1,0 +1,7 @@
+package com.tutorpus.tutorpus.connect.repository;
+
+import com.tutorpus.tutorpus.connect.entity.ClassDay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClassDayRepository extends JpaRepository<ClassDay, Long> {
+}

--- a/src/main/java/com/tutorpus/tutorpus/connect/service/ConnectService.java
+++ b/src/main/java/com/tutorpus/tutorpus/connect/service/ConnectService.java
@@ -1,8 +1,10 @@
 package com.tutorpus.tutorpus.connect.service;
 
 import com.tutorpus.tutorpus.connect.dto.ConnectRequestDto;
+import com.tutorpus.tutorpus.connect.entity.ClassDay;
 import com.tutorpus.tutorpus.connect.entity.Connect;
 import com.tutorpus.tutorpus.connect.entity.Day;
+import com.tutorpus.tutorpus.connect.repository.ClassDayRepository;
 import com.tutorpus.tutorpus.connect.repository.ConnectRepository;
 import com.tutorpus.tutorpus.member.entity.Member;
 import com.tutorpus.tutorpus.member.repository.MemberRepository;
@@ -15,26 +17,32 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConnectService {
     private final MemberRepository memberRepository;
     private final ConnectRepository connectRepository;
+    private final ClassDayRepository classDayRepository;
 
     @Transactional
     public void teacherStudentConnect(ConnectRequestDto connectDto, Member teacher) {
         //학생
+        //TODO: 에러 던지기
         Member student = memberRepository.findByEmail(connectDto.getStudentEmail()).orElse(null);
 
-        //선생님과 학생 연결 정보 저장
+        //선생님과 학생 연결정보
+        Connect connect = Connect.builder()
+                .teacher(teacher)
+                .student(student)
+                .subject(connectDto.getSubject())
+                .build();
+        connectRepository.save(connect);
+
+        //선생님과 학생 요일정보 저장
         connectDto.getTimeSlots().forEach(timeSlot -> {
             //요일 enum으로 변경
             Day day = Day.valueOf(timeSlot.getDay());
-
-            Connect connect = Connect.builder()
-                    .teacher(teacher)
-                    .student(student)
+            ClassDay classDay = ClassDay.builder()
                     .day(day)
                     .startTime(timeSlot.getStartTime())
                     .endTime(timeSlot.getEndTime())
                     .build();
-
-            connectRepository.save(connect);
+            classDayRepository.save(classDay);
         });
     }
 }

--- a/src/main/java/com/tutorpus/tutorpus/student/controller/StudentController.java
+++ b/src/main/java/com/tutorpus/tutorpus/student/controller/StudentController.java
@@ -3,6 +3,7 @@ package com.tutorpus.tutorpus.student.controller;
 import com.tutorpus.tutorpus.auth.LoginUser;
 import com.tutorpus.tutorpus.auth.dto.SessionMember;
 import com.tutorpus.tutorpus.member.entity.Member;
+import com.tutorpus.tutorpus.member.entity.Role;
 import com.tutorpus.tutorpus.student.dto.RequestStudentInfoDto;
 import com.tutorpus.tutorpus.student.service.StudentService;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class StudentController {
 
     @PostMapping("/info")
     public ResponseEntity<?> studentInfo(@RequestBody RequestStudentInfoDto studentInfoDto, @LoginUser Member member){
-        if(member.getRole().equals("TEACHER"))
+        if(member.getRole() == Role.TEACHER)
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("선생님은 학생 추가정보 저장하지 않음.");
         studentService.studentInfo(studentInfoDto, member);
         return ResponseEntity.ok("학생 추가정보 저장 완료");


### PR DESCRIPTION
- 기존에 Connect 엔티티에 수업 일자를 모두 저장했으나, 한 학생이 여러 과목을 수업하는 경우 db관리하기 어려울 것 같아 요일과 수업 시간만 따로 저장하는 ClassDay 엔티티 추가 분리